### PR TITLE
docs: fiks lenkeformat og oppdater wiki-URL i README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@
 
 ## Miljøer
 
-[🚀 Produksjon](https://www.nav.no/arbeidsgiver/ansatte/narmesteleder)
+🚀 [Produksjon](https://www.nav.no/arbeidsgiver/ansatte/narmesteleder)
 
-[🛠️ Utvikling](https://www.ekstern.dev.nav.no/arbeidsgiver/ansatte/narmesteleder)
+🛠️ [Utvikling](https://www.ekstern.dev.nav.no/arbeidsgiver/ansatte/narmesteleder)
 
-[🎬 Demo - skjema for sykmeldt og nærmeste leder](https://demo.ekstern.dev.nav.no/arbeidsgiver/ansatte/narmesteleder)
+🎬 [Demo - skjema for sykmeldt og nærmeste leder](https://demo.ekstern.dev.nav.no/arbeidsgiver/ansatte/narmesteleder)
 
-[🎬 Demo - skjema med forhåndsutfylt sykmeldt](https://demo.ekstern.dev.nav.no/arbeidsgiver/ansatte/narmesteleder/b8dec976-932a-45d3-b1d4-09debe8e44be)
+🎬 [Demo - skjema med forhåndsutfylt sykmeldt](https://demo.ekstern.dev.nav.no/arbeidsgiver/ansatte/narmesteleder/b8dec976-932a-45d3-b1d4-09debe8e44be)
 
 ## Formålet med appen
 
@@ -52,7 +52,7 @@ Brukte endepunkter
 
 ## Utvikling (kjøre lokalt)
 
-For å komme i gang med bygging og kjøring av appen, les vår [wiki for Next.js-applikasjoner](https://github.com/navikt/esyfo-dev-tools/wiki/nextjs-build-run).
+For å komme i gang med å bygge og kjøre appen, se vår [Wiki for frontendapper](https://navikt.github.io/team-esyfo/utvikling/frontend/).
 
 Når appen er startet, åpne http://localhost:3000/arbeidsgiver/ansatte/narmesteleder
 

--- a/README.md
+++ b/README.md
@@ -56,4 +56,10 @@ For å komme i gang med å bygge og kjøre appen, se vår [Wiki for frontendappe
 
 Når appen er startet, åpne http://localhost:3000/arbeidsgiver/ansatte/narmesteleder
 
+## For Nav-ansatte
+
+Interne henvendelser kan sendes via Slack i kanalen [#esyfo](https://nav-it.slack.com/archives/C012X796B4L).
+
+---
+
 [^basepath]: `basePath`-verdien settes i Next.js-konfigurasjonen i `next.config.ts` og angir URL-prefikset som hele appen lever under.


### PR DESCRIPTION
## Beskrivelse

Flytter emoji foran lenkene i miljø-seksjonen slik at hele lenketeksten blir klikkbar, og oppdaterer wiki-lenken for lokal utvikling til ny adresse.

## Endringer

- `README.md`: Emoji plassert utenfor markdown-lenker i miljø-seksjonen
- `README.md`: Wiki-URL oppdatert fra gammel GitHub-wiki til ny Team Esyfo-dokumentasjon

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)