### PR TITLE
chore(pnpm): oppgrader til pnpm 11

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,7 +2,7 @@
 
 ## Build, test, and lint commands
 
-Use `pnpm` (repo is pinned to pnpm 10 / Node 24 via `.mise.toml`).
+Use `pnpm` (repo is pinned to pnpm 11 / Node 24 via `.mise.toml`).
 
 - Install: `pnpm install`
 - Dev server: `pnpm run dev`

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,6 +1,6 @@
 [tools]
 node = "24"
-pnpm = "10"
+pnpm = "11.1.2"
 
 [tasks.install]
 description = "Install dependencies (cached)"

--- a/biome.json
+++ b/biome.json
@@ -7,7 +7,14 @@
   },
   "files": {
     "ignoreUnknown": true,
-    "includes": ["**", "!node_modules", "!.next", "!dist", "!build"]
+    "includes": [
+      "**",
+      "!node_modules",
+      "!.next",
+      "!dist",
+      "!build",
+      "!.github/skills/**/scripts"
+    ]
   },
   "formatter": {
     "enabled": true,

--- a/package.json
+++ b/package.json
@@ -54,5 +54,5 @@
     "@types/react": "19.2.14",
     "@types/react-dom": "19.2.3"
   },
-  "packageManager": "pnpm@10.29.2"
+  "packageManager": "pnpm@11.1.2"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,6 @@
+allowBuilds:
+  esbuild: true
+  lefthook: true
+  sharp: true
+minimumReleaseAge: 4320
+blockExoticSubdeps: true


### PR DESCRIPTION
## Beskrivelse

Oppgraderer repoet fra pnpm 10 til pnpm 11 og legger inn prosjektkonfig for Navs supply-chain-praksis.

## Endringer

- `package.json`: pinner package manager til `pnpm@11.1.2`
- `.mise.toml`: pinner lokal pnpm-toolchain til `11.1.2`
- `pnpm-workspace.yaml`: legger til `minimumReleaseAge: 4320`, `blockExoticSubdeps: true` og eksplisitt `allowBuilds`
- `biome.json`: ignorerer skill-skript fra Biome-format/check
- `.github/copilot-instructions.md`: oppdaterer pnpm-referanse til pnpm 11

## Issue

Closes #316

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)

## Verifisering

- `corepack pnpm@11.1.2 install`
- `mise install pnpm && mise exec -- pnpm --version`
- `corepack pnpm@11.1.2 run test --run`
- `corepack pnpm@11.1.2 run build`
- `corepack pnpm@11.1.2 run check`

## Merknader

`pnpm@11.1.2` er valgt fordi den er en moden pnpm 11-versjon som fungerer med `minimumReleaseAge: 4320`. Nyere pnpm-versjoner kan bumps senere når de er eldre enn tre dager.